### PR TITLE
Update user input function to python3 spec

### DIFF
--- a/xml_tagger.py
+++ b/xml_tagger.py
@@ -140,9 +140,9 @@ def file_writer(old_file, old_location, county_file, file_month, file_day, file_
 # This function handles checking of files against potential matches and initializes the publication date once per program-run
 def file_checker(user_directory):
 
-    file_month = str(raw_input("Please input the month of the publication (MM): "))
-    file_day = str(raw_input("Please input the day of the publication (DD): "))
-    file_year = str(raw_input("Please input the year of the publication (YYYY): "))
+    file_month = str(input("Please input the month of the publication (MM): "))
+    file_day = str(input("Please input the day of the publication (DD): "))
+    file_year = str(input("Please input the year of the publication (YYYY): "))
     print
     
     # This tries to find matches for XML files that exist in all dirs and subdirs of user provided directory


### PR DESCRIPTION
Python2 implementation of "raw_input" is deprecated in python3, which would cause program to crash. [Python3 renamed the "raw_input" function to "input"](https://docs.python.org/3/whatsnew/3.0.html#builtins:~:text=PEP%203111%3A%20raw_input()%20was%20renamed%20to%20input().%20That%20is%2C%20the%20new%20input()%20function%20reads%20a%20line%20from%20sys.stdin%20and%20returns%20it%20with%20the%20trailing%20newline%20stripped.%20It%20raises%20EOFError%20if%20the%20input%20is%20terminated%20prematurely.%20To%20get%20the%20old%20behavior%20of%20input()%2C%20use%20eval(input()).), and doing so here in the code seems to solve the crash, and program behaves as expected.